### PR TITLE
🧛‍♂️ Check for undefined event parameter

### DIFF
--- a/waffle-chai/src/matchers/emit.ts
+++ b/waffle-chai/src/matchers/emit.ts
@@ -61,7 +61,7 @@ export function supportEmit(Assertion: Chai.AssertionStatic) {
       actualArgs.length
     );
     for (let index = 0; index < expectedArgs.length; index++) {
-      if (expectedArgs[index] !== undefined && expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== 'string') {
+      if (expectedArgs[index]?.length !== undefined && typeof expectedArgs[index] !== 'string') {
         for (let j = 0; j < expectedArgs[index].length; j++) {
           new Assertion(actualArgs[index][j]).equal(expectedArgs[index][j]);
         }

--- a/waffle-chai/src/matchers/emit.ts
+++ b/waffle-chai/src/matchers/emit.ts
@@ -61,7 +61,7 @@ export function supportEmit(Assertion: Chai.AssertionStatic) {
       actualArgs.length
     );
     for (let index = 0; index < expectedArgs.length; index++) {
-      if (expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== 'string') {
+      if (expectedArgs[index] !== undefined && expectedArgs[index].length !== undefined && typeof expectedArgs[index] !== 'string') {
         for (let j = 0; j < expectedArgs[index].length; j++) {
           new Assertion(actualArgs[index][j]).equal(expectedArgs[index][j]);
         }


### PR DESCRIPTION
Error thrown when event returns nullish/undefined parameter like empty string or empty array:
`     TypeError: Cannot read property 'length' of undefined
`
This pull request closes https://github.com/EthWorks/Waffle/issues/583