### PR TITLE
🦊 Handle `revertedWith` with an empty `revertString`

### DIFF
--- a/waffle-chai/src/matchers/revertedWith.ts
+++ b/waffle-chai/src/matchers/revertedWith.ts
@@ -21,12 +21,12 @@ export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
 
     const onError = (error: any) => {
       const revertString = error?.receipt?.revertString ?? decodeRevertString(error);
-      if (revertString) {
+      if (revertString !== undefined) {
         this.assert(
           revertString === revertReason,
-          `Expected transaction to be reverted with ${revertReason}, but other reason was found: ${revertString}`,
-          `Expected transaction NOT to be reverted with ${revertReason}`,
-          `Transaction reverted with ${revertReason}.`,
+          `Expected transaction to be reverted with "${revertReason}", but other reason was found: "${revertString}"`,
+          `Expected transaction NOT to be reverted with "${revertReason}"`,
+          `Transaction reverted with "${revertReason}".`,
           error
         );
         return error;
@@ -51,9 +51,9 @@ export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
 
       this.assert(
         isReverted || isThrown,
-        `Expected transaction to be reverted with ${revertReason}, but other exception was thrown: ${error}`,
-        `Expected transaction NOT to be reverted with ${revertReason}`,
-        `Transaction reverted with ${revertReason}.`,
+        `Expected transaction to be reverted with "${revertReason}", but other exception was thrown: ${error}`,
+        `Expected transaction NOT to be reverted with "${revertReason}"`,
+        `Transaction reverted with "${revertReason}".`,
         error
       );
       return error;

--- a/waffle-chai/test/matchers/reverted.test.ts
+++ b/waffle-chai/test/matchers/reverted.test.ts
@@ -111,6 +111,13 @@ describe('INTEGRATION: Matchers: revertedWith', () => {
     await expect(matchers.doThrowAndModify()).to.be.revertedWith('');
   });
 
+  it('Throw with modification: success, properly handle common substring', async () => {
+    // https://github.com/NomicFoundation/hardhat/issues/2234#issuecomment-1045974424
+    await expect(
+      expect(matchers.doThrowAndModify()).to.be.revertedWith('fa')
+    ).to.eventually.be.rejectedWith('Expected transaction to be reverted with "fa", but other reason was found: ""');
+  });
+
   it('Throw with modification: fail when message is expected', async () => {
     await expect(
       expect(matchers.doThrowAndModify()).to.be.revertedWith('Message other than empty string')


### PR DESCRIPTION
https://github.com/TrueFiEng/Waffle/issues/608
https://github.com/NomicFoundation/hardhat/issues/2234#issuecomment-1045974424
Supersedes https://github.com/TrueFiEng/Waffle/pull/627