### PR TITLE
Add contract function hints to the MockContract.mock object

### DIFF
--- a/.changeset/two-rice-teach.md
+++ b/.changeset/two-rice-teach.md
@@ -1,0 +1,5 @@
+---
+"@ethereum-waffle/mock-contract": patch
+---
+
+Add contract function hints to the `MockContract.mock` object


### PR DESCRIPTION
This change is backwards compatible as it uses an optional generic, that is by default set to `BaseContract`, which contains a mapped object `functions: { [ name: string ]: ... };` that provides the same namespace.

I've been using this already with this ambient type declaration
```
declare type BaseContract = import('ethers').BaseContract
declare type _MockContract = import('ethereum-waffle').MockContract
declare type Stub = import('ethereum-waffle').Stub
interface MockContract<T extends BaseContract = BaseContract> extends _MockContract {
  mock: {
    [key in keyof T['functions']]: Stub
  }
}
```

![image](https://user-images.githubusercontent.com/2313018/181121638-77a99766-fd39-4e39-8f7f-c9a815eec744.png)
