### PR TITLE
🎩 Allow string addresses in `changeTokenBalance`

### DIFF
--- a/.changeset/beige-melons-prove.md
+++ b/.changeset/beige-melons-prove.md
@@ -1,0 +1,5 @@
+---
+"@ethereum-waffle/chai": patch
+---
+
+🎩 Allow string addresses in `changeTokenBalance`

--- a/waffle-chai/src/matchers/changeEtherBalance.ts
+++ b/waffle-chai/src/matchers/changeEtherBalance.ts
@@ -18,6 +18,12 @@ export function supportChangeEtherBalance(Assertion: Chai.AssertionStatic) {
       if (!('txResponse' in this)) {
         throw new Error('The changeEtherBalance matcher must be called on a transaction');
       }
+      if (typeof account === 'string') {
+        throw new Error(
+          'A string address cannot be used as an account in changeEtherBalance.' +
+          ' Expecting an instance of Ethers Account.'
+        );
+      }
       return Promise.all([
         getBalanceChange(this.txResponse, account, options),
         getAddressOf(account)

--- a/waffle-chai/src/matchers/changeEtherBalances.ts
+++ b/waffle-chai/src/matchers/changeEtherBalances.ts
@@ -17,6 +17,12 @@ export function supportChangeEtherBalances(Assertion: Chai.AssertionStatic) {
       if (!('txResponse' in this)) {
         throw new Error('The changeEtherBalances matcher must be called on a transaction');
       }
+      if (accounts.some(account => typeof account === 'string')) {
+        throw new Error(
+          'A string address cannot be used as an account in changeEtherBalances.' +
+          ' Expecting an instance of Ethers Account.'
+        );
+      }
       return Promise.all([
         getBalanceChanges(this.txResponse, accounts, options),
         getAddresses(accounts)

--- a/waffle-chai/src/matchers/changeTokenBalance.ts
+++ b/waffle-chai/src/matchers/changeTokenBalance.ts
@@ -6,7 +6,7 @@ export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod('changeTokenBalance', function (
     this: any,
     token: Contract,
-    account: Account,
+    account: Account | string,
     balanceChange: BigNumberish
   ) {
     callPromise(this);
@@ -15,7 +15,7 @@ export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
       if (!('txReceipt' in this)) {
         throw new Error('The changeTokenBalance matcher must be called on a transaction');
       }
-      const address = await getAddressOf(account);
+      const address = typeof account === 'string' ? account : await getAddressOf(account);
       const actualChanges = await getBalanceChange(this.txReceipt, token, address);
       return [actualChanges, address];
     }).then(([actualChange, address]: [BigNumber, string]) => {

--- a/waffle-chai/src/matchers/changeTokenBalances.ts
+++ b/waffle-chai/src/matchers/changeTokenBalances.ts
@@ -6,7 +6,7 @@ export function supportChangeTokenBalances(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod('changeTokenBalances', function (
     this: any,
     token: Contract,
-    accounts: Account[],
+    accounts: (Account | string)[],
     balanceChanges: BigNumberish[]
   ) {
     callPromise(this);
@@ -40,8 +40,10 @@ export function supportChangeTokenBalances(Assertion: Chai.AssertionStatic) {
   });
 }
 
-function getAddresses(accounts: Account[]) {
-  return Promise.all(accounts.map((account) => getAddressOf(account)));
+function getAddresses(accounts: (Account | string)[]) {
+  return Promise.all(accounts.map(
+    (account) => typeof account === 'string' ? account : getAddressOf(account)
+  ));
 }
 
 async function getBalances(token: Contract, addresses: string[], blockNumber: number) {

--- a/waffle-chai/test/matchers/changeEtherBalanceTest.ts
+++ b/waffle-chai/test/matchers/changeEtherBalanceTest.ts
@@ -37,6 +37,20 @@ export const changeEtherBalanceTest = (
         ).to.changeEtherBalance(sender, '-200');
       });
 
+      it('Breaks in a predictable way when addresses are passed as string', async () => {
+        await expect(
+          expect(() =>
+            sender.sendTransaction({
+              to: receiver.address,
+              value: 200
+            })
+          ).to.changeEtherBalance(sender.address, '-200')
+        ).to.eventually.be.rejectedWith(
+          'A string address cannot be used as an account in changeEtherBalance.' +
+          ' Expecting an instance of Ethers Account.'
+        );
+      });
+
       it('Should pass when expected balance change is passed as int and is equal to an actual', async () => {
         await expect(() =>
           sender.sendTransaction({

--- a/waffle-chai/test/matchers/changeEtherBalancesTest.ts
+++ b/waffle-chai/test/matchers/changeEtherBalancesTest.ts
@@ -40,7 +40,7 @@ export const changeEtherBalancesTest = (
       });
 
       it('Breaks in a predictable way when addresses are passed as string', async () => {
-        await (
+        await expect(
           expect(() =>
             sender.sendTransaction({
               to: contract.address,

--- a/waffle-chai/test/matchers/changeEtherBalancesTest.ts
+++ b/waffle-chai/test/matchers/changeEtherBalancesTest.ts
@@ -38,6 +38,20 @@ export const changeEtherBalancesTest = (
           })
         ).to.changeEtherBalances([sender, contract], [-200, 200]);
       });
+
+      it('Breaks in a predictable way when addresses are passed as string', async () => {
+        await (
+          expect(() =>
+            sender.sendTransaction({
+              to: contract.address,
+              value: 200
+            })
+          ).to.changeEtherBalances([sender.address, contract.address], [-200, 200])
+        ).to.eventually.be.rejectedWith(
+          'A string address cannot be used as an account in changeEtherBalances.' +
+          ' Expecting an instance of Ethers Account.'
+        );
+      });
     });
 
     describe('Change balance, multiple accounts', () => {

--- a/waffle-chai/test/matchers/changeTokenBalanceTest.ts
+++ b/waffle-chai/test/matchers/changeTokenBalanceTest.ts
@@ -29,6 +29,14 @@ export const changeTokenBalanceTest = (provider: TestProvider) => {
       ).to.changeTokenBalance(token, receiver, 200);
     });
 
+    it('Works with address passed as a string', async () => {
+      await token.approve(receiver.address, 200);
+      const connectedToken = token.connect(receiver);
+      await expect(() =>
+        connectedToken.transferFrom(sender.address, receiver.address, 200)
+      ).to.changeTokenBalance(token, receiver.address, 200);
+    });
+
     it('Should pass when expected balance change is passed as string and is equal to an actual', async () => {
       await expect(() =>
         token.transfer(receiver.address, 200)

--- a/waffle-chai/test/matchers/changeTokenBalancesTest.ts
+++ b/waffle-chai/test/matchers/changeTokenBalancesTest.ts
@@ -25,6 +25,12 @@ export const changeTokenBalancesTest = (provider: TestProvider) => {
       ).to.changeTokenBalances(token, [sender, receiver], ['-200', 200]);
     });
 
+    it('Works with addresses passed as strings', async () => {
+      await expect(() =>
+        token.transfer(receiver.address, 200)
+      ).to.changeTokenBalances(token, [sender.address, receiver.address], ['-200', 200]);
+    });
+
     it('Should pass when negated and numbers don\'t match', async () => {
       await expect(() =>
         token.transfer(receiver.address, 200)


### PR DESCRIPTION
- `changeEtherBalance` cannot accept a string address, because it relies on `account.provider` for reading balance. `changeTokenBalance` has a provider from the contract parameter.
- Closes https://github.com/TrueFiEng/Waffle/issues/567