### PR TITLE
🧠 Fix error when address length less than 20

### DIFF
--- a/.changeset/red-rats-jump.md
+++ b/.changeset/red-rats-jump.md
@@ -1,0 +1,5 @@
+---
+"@ethereum-waffle/provider": patch
+---
+
+🧠 Fix error when address length less than 20

--- a/waffle-provider/src/CallHistory.ts
+++ b/waffle-provider/src/CallHistory.ts
@@ -96,7 +96,7 @@ export class CallHistory {
 
 function toRecordedCall(message: any): RecordedCall {
   return {
-    address: message.to ? utils.getAddress(utils.hexlify(message.to)) : undefined,
+    address: message.to ? decodeAddress(message.to) : undefined,
     data: message.data ? utils.hexlify(message.data) : '0x'
   };
 }
@@ -131,4 +131,15 @@ function decodeCallData(callData: any) {
 function decodeNumber(data: Buffer): number {
   const newData = Buffer.concat([data, Buffer.alloc(32, 0)]);
   return newData.readUInt32LE();
+}
+
+/**
+ * Decodes a address taken from EVM execution step
+ * into a checksumAddress.
+ */
+function decodeAddress(data: Buffer): string {
+  if (data.length < 20) {
+    data = Buffer.concat([Buffer.alloc(20 - data.length, 0), data]);
+  }
+  return utils.getAddress(utils.hexlify(data));
 }


### PR DESCRIPTION
address with prefix 0 would thrown an error
```ts
utils.getAddress(utils.hexlify(0))
```