### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/release-notes/2.0.0.md
+++ b/docs/release-notes/2.0.0.md
@@ -4,9 +4,9 @@
 In version 2.0 we introduce documentation available under url: [https://ethereum-waffle.readthedocs.io/](https://ethereum-waffle.readthedocs.io/).
 
 ## Faster compilation with native and dockerized solc
-By default, Waffle uses solcjs. Solcjs is solidity complier cross-complied to javascript. It can be slow for bigger projects, but require no installation. You can now use native and dockerized solc instead.
+By default, Waffle uses solcjs. Solcjs is solidity compiler cross-complied to javascript. It can be slow for bigger projects, but require no installation. You can now use native and dockerized solc instead.
 
-Read more about fast compiliation [here](https://ethereum-waffle.readthedocs.io/en/latest/compilation.html)
+Read more about fast compilation [here](https://ethereum-waffle.readthedocs.io/en/latest/compilation.html)
 
 ## New chai matcher: changeBalance and changeBalances
 Waffle 2.0 introduces `changeBalance` and `changeBalances` matchers that allows to check if balance of an account(s) changed.
@@ -24,10 +24,10 @@ Read more about fixtures [here](https://ethereum-waffle.readthedocs.io/en/latest
 
 
 ## Others
-* Waffle now supports config file in both `json` and `js` extenstions.
+* Waffle now supports config file in both `json` and `js` extensions.
 * Linking should work for both solidity 4 and solidity 5
-* Waffle is now officialy released under MIT license
-* Compiliation is covered with extensive end-to-end tests
+* Waffle is now officially released under MIT license
+* Compilation is covered with extensive end-to-end tests
 
 ## Breaking changes
 * `getWallet()` is not `async` anymore

--- a/docs/release-notes/2.0.1.md
+++ b/docs/release-notes/2.0.1.md
@@ -5,4 +5,4 @@ This release introduces minor fixes and functionalities.
 Thanks to the work of [@yaram](https://github.com/yaram) Waffle should now work on windows.
 
 ## Configurable allowedPaths for native solc compilation
-Waffle configuration file has now new field: `allowedPaths`. It allows to adding extra `--allow-paths` for natvie solc compiler. That might be required to make Waffle work with monorepos using [lerna](https://lernajs.io/).
+Waffle configuration file has now new field: `allowedPaths`. It allows to adding extra `--allow-paths` for native solc compiler. That might be required to make Waffle work with monorepos using [lerna](https://lernajs.io/).


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `complier` to `compiler`
Corrected `compiliation` to `compilation`
Corrected `extenstions` to `extensions`
Corrected `officialy` to `officially`
Corrected `Compiliation` to `Compilation`
Corrected `natvie` to `native`


Please review the changes and let me know if any additional changes are needed.