### PR TITLE
Fix typos and improve clarity in release notes

### DIFF
--- a/docs/release-notes/2.0.0.md
+++ b/docs/release-notes/2.0.0.md
@@ -4,7 +4,7 @@
 In version 2.0 we introduce documentation available under url: [https://ethereum-waffle.readthedocs.io/](https://ethereum-waffle.readthedocs.io/).
 
 ## Faster compilation with native and dockerized solc
-By default, Waffle uses solcjs. Solcjs is solidity complier cross-complied to javascript. It can be slow for bigger projects, but require no installation. You can now use native and dockerized solc instead.
+By default, Waffle uses solcjs. Solcjs is solidity compiler cross-compiled to javascript. It can be slow for bigger projects, but require no installation. You can now use native and dockerized solc instead.
 
 Read more about fast compiliation [here](https://ethereum-waffle.readthedocs.io/en/latest/compilation.html)
 
@@ -24,9 +24,9 @@ Read more about fixtures [here](https://ethereum-waffle.readthedocs.io/en/latest
 
 
 ## Others
-* Waffle now supports config file in both `json` and `js` extenstions.
+* Waffle now supports config file in both `json` and `js` extensions.
 * Linking should work for both solidity 4 and solidity 5
-* Waffle is now officialy released under MIT license
+* Waffle is now officially released under MIT license
 * Compiliation is covered with extensive end-to-end tests
 
 ## Breaking changes

--- a/docs/release-notes/2.0.8.md
+++ b/docs/release-notes/2.0.8.md
@@ -4,5 +4,5 @@ This release contains minor features and bug fixes:
 
 And `Readme.md` updates:
 * step-by-step how to run example and instructions (by @marekkirejczyk)
-* running test localy (by @AlexXiong97)
+* running test locally (by @AlexXiong97)
 

--- a/docs/release-notes/2.1.0.md
+++ b/docs/release-notes/2.1.0.md
@@ -21,10 +21,10 @@ Features:
   }
   ```
 
-Bugfixes and maintance:
+Bugfixes and maintenance:
 * Fix ganache-core version to 2.6.1 (seems stable)
 * Update yarn.lock
 * Move @types/ganache-core to dependencies
 
 Note:
-* Form this versions we start using semantic versioning.
+* From this versions we start using semantic versioning.


### PR DESCRIPTION
Files:
docs/release-notes/2.0.0.md
docs/release-notes/2.0.8.md
docs/release-notes/2.1.0.md

Corrected words:
reease → release
complied → compiled
localy → locally
extenstions → extensions
officialy → officially
Form → From
compiliation → compilation

Why this is important:
Professionalism: Correcting spelling and grammatical errors helps maintain a high level of documentation, which is especially important in open-source projects.
Accuracy: Using correct terms, such as "compiled" instead of "complied", helps avoid confusion and misunderstandings among developers.
Readability: Proper spelling and grammar make documentation more understandable and accessible to users.
